### PR TITLE
footnote formatting

### DIFF
--- a/asudis.sty
+++ b/asudis.sty
@@ -312,3 +312,15 @@ letterpaper}%,showframe,showcrop}
   \singlespace
   {\textbf{#1:} #2\par}
 }
+
+%
+% Modify footnotes to be single spaced per footnote, double in between
+%
+
+\setlength{\footnotesep}{\baselineskip} %double space between footnotes
+
+\let\oldfootnoterule\footnoterule %dont put a gap between the line and the first footnote
+\def\footnoterule{\oldfootnoterule\vspace{-0.2\baselineskip}}
+
+\let\oldfn\footnote   %single space individual footnotes
+\renewcommand{\footnote}[1]{\singlespace\oldfn{#1}\doublespace}


### PR DESCRIPTION
From the format guide (http://graduate.asu.edu/sites/default/files/GraduateEducationFormatManual.pdf):

"You must single-space individual footnotes and reference entries, then double-space 
between each note and entry. "

I'm not positive this fully complies with that requirement -  the definition of footnotesep may not be exact. If changes are required I'll file another pull request when I get hassled during format review.
