### PR TITLE
Prevent orphans and windows

### DIFF
--- a/asudis.sty
+++ b/asudis.sty
@@ -328,6 +328,6 @@ letterpaper}%,showframe,showcrop}
 %
 % Set penalties for orphans and windows extremely high to prevent them
 %
-\widowpenalty10000
-\clubpenalty10000
+\widowpenalty=10000
+\clubpenalty=10000
 


### PR DESCRIPTION
This one is purely a stylistic issue (so accept it or don't, I don't care), but I absolutely cannot stand orphans and windows and prefer to have LaTeX clean that up for me. Per page 18 in the style guide this is allowed.
