### PR TITLE
adjusted toc header

### DIFF
--- a/dis.tex
+++ b/dis.tex
@@ -75,6 +75,10 @@
 \renewcommand{\chaptername}{APPENDIX}
 \addtocontents{toc}{APPENDIX \par}
 \appendix
+% Headers for TOC pages involving only appendices should have the left-heading
+% "APPENDIX", instead of "CHAPTER"
+\addtocontents{toc}{%
+    \protect\afterpage{\protect\lhead{APPENDIX}\protect\rhead{Page}}}
 \include{appendix1}
 \include{vita}
 \end{document}


### PR DESCRIPTION
If a dissertation has lots of chapters followed by lots of appendices, the TOC might look like this:

- Page 1, involving only chapters 
- Page 2, involving chapters and appendices
- Page 3, involving only appendices

The left headers for Pages 1,2 should be "CHAPTER" but the header for page 3 should be "APPENDIX". 

This commit integrates this change.